### PR TITLE
fix `nix develop .#poetry` and `nix flake show`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,8 +161,8 @@
         # $> poetry install
         #
         # Use this shell for changes to pyproject.toml and poetry.lock.
-        devShells.poetry = pkgs.mkShell {
-          packages = [ pkgs.poetry ];
+        poetry = pkgs.${system}.mkShell {
+          packages = [ pkgs.${system}.poetry ];
         };
       });
     };


### PR DESCRIPTION
`devShells.<system>.devShells.poetry` broke `nix flake show`, because [flakes can never have derivations nested in another attribute set](https://discourse.nixos.org/t/flake-questions/8741). And it can't be called via `nix develop.#poetry`.

Here how it looks now:
![image](https://github.com/user-attachments/assets/529085de-d535-45ee-a924-150c84e95257)
